### PR TITLE
Fix the compilation error when using -Wpedantic

### DIFF
--- a/c++/namegen.h
+++ b/c++/namegen.h
@@ -262,7 +262,7 @@ public:
 	std::string toString();
 };
 
-};
+}
 
 std::wstring towstring(const std::string& s);
 std::string tostring(const std::wstring& s);


### PR DESCRIPTION
namegen.h|265|error: extra ‘;’ [-Wpedantic]|