### PR TITLE
Virtual destructor fix

### DIFF
--- a/c++/namegen.h
+++ b/c++/namegen.h
@@ -159,6 +159,7 @@ class Generator
 		group_types_t type;
 
 		Group(group_types_t type_);
+		virtual ~Group() { }
 
                 std::unique_ptr<Generator> produce();
 		void split();


### PR DESCRIPTION
This is a tiny tiny one, it just fixes the compiler warnings regarding a class with virtual objects having a non-virtual destructor. There's no actual functionality changes beyond that.